### PR TITLE
Trello 119/image default improvements

### DIFF
--- a/client/src/components/overview/Overview.jsx
+++ b/client/src/components/overview/Overview.jsx
@@ -21,7 +21,6 @@ const OverviewStyle = styled.div`
   padding: 15px 0px;
 `;
 
-
 const Overview = (props) => {
   const [price, setPrice] = useState();
   const [style, setStyle] = useState({});

--- a/client/src/components/overview/Overview.jsx
+++ b/client/src/components/overview/Overview.jsx
@@ -12,7 +12,7 @@ const info_height = 175;
 const style_height = 150;
 const cart_height = 150;
 const image_height = info_height + style_height + cart_height;
-const image_width = image_height * 1.1;
+const image_width = Math.floor(image_height * 1.15)-.01;
 
 const OverviewStyle = styled.div`
   display: grid;

--- a/client/src/components/overview/components/ArrowButton.jsx
+++ b/client/src/components/overview/components/ArrowButton.jsx
@@ -20,7 +20,7 @@ const arrowSymbols = {
   'down': faChevronDown,
 }
 
-const ArrowButton = ({handleClick, direction, active, height, carousel_height}) =>  {
+const ArrowButton = ({handleClick, direction, active, height, carousel_height }) =>  {
   const position = {
     'right': 'position: absolute;',
     'left': 'position: absolute;',

--- a/client/src/components/overview/components/ArrowButton.jsx
+++ b/client/src/components/overview/components/ArrowButton.jsx
@@ -5,7 +5,7 @@ import { faArrowRight, faArrowLeft, faChevronUp, faChevronDown } from '@fortawes
 const { useEffect, useState } = React;
 
 const button_height = 25;
-const button_margin = 5;
+const button_margin = 0;
 const sideOffset = {
   'right': 'right: 25px;',
   'left': 'left: 75px;',

--- a/client/src/components/overview/components/ArrowButton.jsx
+++ b/client/src/components/overview/components/ArrowButton.jsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronRight, faChevronLeft, faChevronUp, faChevronDown } from '@fortawesome/free-solid-svg-icons'
+import { faArrowRight, faArrowLeft, faChevronUp, faChevronDown } from '@fortawesome/free-solid-svg-icons'
 const { useEffect, useState } = React;
 
 const button_height = 25;
 const button_margin = 5;
 const sideOffset = {
   'right': 'right: 25px;',
-  'left': 'left: 100px;',
+  'left': 'left: 75px;',
   'up': '',//'left 50px;',
   'down': '',//'left 50px;',
 }
 
 const arrowSymbols = {
-  'right': faChevronRight,
-  'left': faChevronLeft,
+  'right': faArrowRight,
+  'left': faArrowLeft,
   'up': faChevronUp,
   'down': faChevronDown,
 }
@@ -44,9 +44,8 @@ const ArrowButton = ({handleClick, direction, active, height, carousel_height}) 
       ${topOffset[direction]}
       ${sideOffset[direction]}
       height: ${button_height}px;
-      color: white;
-      background: #ccc;
-      border: .25pt solid #eee;
+      color: #666;
+      background: white;
       width: 25px;
       justify-content: center;
       border-radius: 50%;

--- a/client/src/components/overview/components/ImageGallery.jsx
+++ b/client/src/components/overview/components/ImageGallery.jsx
@@ -27,6 +27,7 @@ const imageGalleryStyle = {
   width: '100%',
   'overflow': 'hidden',
   cursor: 'zoom-in',
+  boxSizing: 'border-box'
 }
 
 const ImageGallery = (props) => {

--- a/client/src/components/overview/components/ImageGallery.jsx
+++ b/client/src/components/overview/components/ImageGallery.jsx
@@ -18,7 +18,7 @@ const Image = styled.div`
 
 const imageGalleryStyle = {
   'border': '1pt solid #eee',
-  'borderRadius': '5px',
+  'borderRadius': '10px',
   'gridColumnStart': '2',
   'gridRowStart': '1',
   'gridRowEnd': '4',
@@ -35,6 +35,15 @@ const ImageGallery = (props) => {
   const [photoIndex, setPhotoIndex] = useState(0);
   const [translate, setTranslate] = useState(0);
   const transition = 0.45;
+
+  //if the style changes, make sure the current photoIndex is valid
+  useEffect(() => {
+    if (props.photos !== undefined) {
+      if (photoIndex >= props.photos.length) {
+        setPhotoIndex(props.photos.length - 1);
+      }
+    }
+  }, [props.photos]);
 
   const handleLeftClick = (e) => {
     e.preventDefault();

--- a/client/src/components/overview/components/Thumbnail.jsx
+++ b/client/src/components/overview/components/Thumbnail.jsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 //import ArrowButton from './ArrowButton.jsx';
 const { useState, useEffect } = React;
 
+const selected_expand = 1.15;
+
 const Thumbnail = ({ photoUrl, width, i, selected, handleClick }) => {
 
   return (
@@ -11,10 +13,10 @@ const Thumbnail = ({ photoUrl, width, i, selected, handleClick }) => {
       <div key={i}
         onClick={e => handleClick(e, i)}
         css={css`
-        height: ${width}px;
-        width: ${width}px;
+        height: ${selected ? width * selected_expand : width}px;
+        width: ${selected ? width * selected_expand : width}px;
         border-radius: 10%;
-        ${selected ? `border: 2.5pt solid #666;` : `border: 0.5pt solid #eee;`}
+        ${selected ? `border: 2pt solid #ddd;` : `border: 0.5pt solid #eee;`}
         background-image: url(${photoUrl});
         background-size: cover;
         background-repeat: no-repeat;

--- a/client/src/components/overview/components/ThumbnailCarousel.jsx
+++ b/client/src/components/overview/components/ThumbnailCarousel.jsx
@@ -8,7 +8,7 @@ const { useState, useEffect } = React;
 const ThumbnailCarousel = ({ photos, photoIndex, handleClick, height }) => {
   const gallery_height = height;
   const carousel_height = 400;
-  const n_max_thumbnails = 4;
+  const n_max_thumbnails = 7;
   const min_thumbnail_index = n_max_thumbnails - 1;
   let carousel_spacing = carousel_height / n_max_thumbnails;
   const thumbnail_width = .8 * carousel_spacing;
@@ -20,7 +20,10 @@ const ThumbnailCarousel = ({ photos, photoIndex, handleClick, height }) => {
     width: `${carousel_spacing}px`,
     'overflow': 'hidden',
     position: 'absolute',
-    top: `${height/2 - carousel_height/2}px`
+    //top: `${height/2 - carousel_height/2}px`
+    top: '0',
+    bottom: '0',
+    margin: 'auto 0',
   }
   const [translate, setTranslate] = useState(0);
   const [thumbnailIndex, setThumbnailIndex] = useState(min_thumbnail_index);
@@ -53,7 +56,9 @@ const ThumbnailCarousel = ({ photos, photoIndex, handleClick, height }) => {
         photos !== undefined &&
         <div style={{
           position: 'absolute',
-          top: `${(450 - gallery_height) / 2}px`,
+          top: '0',
+          bottom: '0',
+          margin: 'auto 0',
           left: '5px',
           display: 'flex',
           flexShrink: '0',

--- a/client/src/components/overview/components/ThumbnailCarousel.jsx
+++ b/client/src/components/overview/components/ThumbnailCarousel.jsx
@@ -7,8 +7,8 @@ const { useState, useEffect } = React;
 
 const ThumbnailCarousel = ({ photos, photoIndex, handleClick, height }) => {
   const gallery_height = height;
-  const carousel_height = 350;
-  const n_max_thumbnails = 7;
+  const carousel_height = 400;
+  const n_max_thumbnails = 4;
   const min_thumbnail_index = n_max_thumbnails - 1;
   let carousel_spacing = carousel_height / n_max_thumbnails;
   const thumbnail_width = .8 * carousel_spacing;

--- a/client/src/components/overview/components/ThumbnailCarousel.jsx
+++ b/client/src/components/overview/components/ThumbnailCarousel.jsx
@@ -2,17 +2,18 @@ import React from 'react';
 import styled from 'styled-components';
 import Thumbnail from './Thumbnail.jsx';
 import ArrowButton from './ArrowButton.jsx';
-//import ArrowButton from './ArrowButton.jsx';
 const { useState, useEffect } = React;
 
+const n_max_thumbnails = 7;
+const transition = 0.3;
+const min_thumbnail_index = n_max_thumbnails - 1;
+
 const ThumbnailCarousel = ({ photos, photoIndex, handleClick, height }) => {
+  /* styles */
   const gallery_height = height;
-  const carousel_height = 400;
-  const n_max_thumbnails = 7;
-  const min_thumbnail_index = n_max_thumbnails - 1;
-  let carousel_spacing = carousel_height / n_max_thumbnails;
-  const thumbnail_width = .8 * carousel_spacing;
-  const transition = 0.3;
+  const carousel_height = height * .85;
+  const carousel_spacing = carousel_height / n_max_thumbnails;
+  const thumbnail_width = .75 * carousel_spacing;
   const thumbnailCarouselStyle = {
     display: 'flex',
     flexDirection: 'column',
@@ -20,13 +21,16 @@ const ThumbnailCarousel = ({ photos, photoIndex, handleClick, height }) => {
     width: `${carousel_spacing}px`,
     'overflow': 'hidden',
     position: 'absolute',
-    //top: `${height/2 - carousel_height/2}px`
     top: '0',
+    left: '0',
     bottom: '0',
     margin: 'auto 0',
   }
+
+  /* states */
   const [translate, setTranslate] = useState(0);
   const [thumbnailIndex, setThumbnailIndex] = useState(min_thumbnail_index);
+
   useEffect(() => {
     if (photoIndex > thumbnailIndex) {
       setTranslate((photoIndex - min_thumbnail_index) * carousel_spacing);
@@ -59,7 +63,7 @@ const ThumbnailCarousel = ({ photos, photoIndex, handleClick, height }) => {
           top: '0',
           bottom: '0',
           margin: 'auto 0',
-          left: '5px',
+          left: `10px`,
           display: 'flex',
           flexShrink: '0',
           flexDirection: 'column',
@@ -67,7 +71,7 @@ const ThumbnailCarousel = ({ photos, photoIndex, handleClick, height }) => {
           height: `${gallery_height}px`,
           width: `${carousel_spacing}px`,
         }}>
-          <ArrowButton direction="up" handleClick={handleUpClick} active={thumbnailIndex > n_max_thumbnails - 1} height={height} carousel_height={carousel_height} />
+          <ArrowButton direction="up" handleClick={handleUpClick} active={thumbnailIndex > n_max_thumbnails - 1} height={height} carousel_height={carousel_height}/>
           <div style={thumbnailCarouselStyle}>
             {photos.map((photo, i) => (
               <div key={photo + i} style={{


### PR DESCRIPTION
- adjust thumbnail sizing for 7 thumbnails
- get rid of sliver of pixels on side of image gallery
- change styling of thumbnail and image arrows
- ensure that photoIndex is not too large when switching styles